### PR TITLE
add liveness probes

### DIFF
--- a/kubernetes-manifests/file-6.yaml
+++ b/kubernetes-manifests/file-6.yaml
@@ -18,4 +18,12 @@ spec:
           containers:
             - image: python:3.9.10-alpine
               name: elasticsearch-snapshot
+              livenessProbe:
+                exec:
+                  command:
+                  - /bin/sh
+                  - -c
+                  - "/usr/bin/my-application-jobs --alive"
+                initialDelaySeconds: 10
+                periodSeconds: 5
   schedule: 0 10,22 * * *


### PR DESCRIPTION
Add liveness probes Liveness probe is intended to ensure that workload remains healthy during its entire execution lifecycle